### PR TITLE
Update Trevis to use openjdk10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10
   - openjdk8
+  - openjdk10
+  - openjdk11


### PR DESCRIPTION
Update Trevis to use oraclejdk10, openjdk10 and openjdk11